### PR TITLE
#61 描画対象WidgetのParentを戻す処理を追加

### DIFF
--- a/Source/UI_Blooman/Private/FakeBloomUI.cpp
+++ b/Source/UI_Blooman/Private/FakeBloomUI.cpp
@@ -236,9 +236,9 @@ FString UFakeBloomUI::GetBloomTextureStat() const
     const int32 OverhangedSizeY(BaseSizeY + BaseParameter.Overhang.GetSizeY());
 
     std::ostringstream oss;
-    oss << "  Widget Size: " << std::setw(4) << BaseSizeX << "x" << std::setw(4) << BaseSizeY << std::endl;
+    oss << "  Widget Res.: " << std::setw(4) << BaseSizeX << "x" << std::setw(4) << BaseSizeY << std::endl;
     oss << "   +Overhange: " << std::setw(4) << OverhangedSizeX << "x" << std::setw(4) << OverhangedSizeY << std::endl;
-    oss << " Texture Size: " << std::setw(4) << TexSizeX << "x" << std::setw(4) << TexSizeY << std::endl;
+    oss << " Texture Res.: " << std::setw(4) << TexSizeX << "x" << std::setw(4) << TexSizeY << std::endl;
     oss << " Texture Type: " << (BaseParameter.IsUsingValidTexture() ? "Static Texture" : "Render Target") << std::endl;;
     oss << "Resource Size: " << ResourceSize << " KB";
     return oss.str().c_str();

--- a/Source/UI_Blooman/Private/FakeBloomUI_Builder.cpp
+++ b/Source/UI_Blooman/Private/FakeBloomUI_Builder.cpp
@@ -66,6 +66,8 @@ bool UFakeBloomUI_Builder::DrawWidgetToTarget(UTextureRenderTarget2D* Target,
 
         WidgetRenderer->ViewOffset = DrawOffset - ContentPos;
 
+        TSharedPtr<SWidget> OldParent = Content->GetParentWidget();
+
         // OffsetしたCanvas
         TSharedRef<SConstraintCanvas> Canvas = SNew(SConstraintCanvas)
             + SConstraintCanvas::Slot()
@@ -114,6 +116,10 @@ bool UFakeBloomUI_Builder::DrawWidgetToTarget(UTextureRenderTarget2D* Target,
         }
 #endif
 
+        if (OldParent.IsValid())
+        {
+            Content->AssignParentWidget(OldParent);
+        }
 
 #else /* シンプル版 */
         WidgetRenderer->ViewOffset = DrawOffset;


### PR DESCRIPTION
StandaloneやPackageでFakeBloom下のボタンがクリックイベントを適切に処理できなくなる現象に対応