### PR TITLE
Calculate Opacity Using SWidget Parent Instead of UWidget Parent

### DIFF
--- a/Source/UI_Blooman/Private/FakeBloomUI.cpp
+++ b/Source/UI_Blooman/Private/FakeBloomUI.cpp
@@ -80,17 +80,19 @@ void UFakeBloomUI::OnPaintPreProcess(const FFakeBloomUI_PreProcessArgs& args)
 
 void UFakeBloomUI::OnPaint(FPaintContext& Context)
 {
-    float Opacity = 1.0f;
+    float AccumulatedOpacity = 1.0f;
     {
-        UWidget* Widget = this;
-        while (Widget) {
-            Opacity *= Widget->GetRenderOpacity();
-            Widget = Widget->GetParent();
+        TSharedPtr<SWidget> CurrentWidget = MyFakeBloomUI;
+        while (CurrentWidget.IsValid())
+        {
+            AccumulatedOpacity *= CurrentWidget->GetRenderOpacity();
+            CurrentWidget = CurrentWidget->GetParentWidget();
         }
+
     }
 
     if (Painter) {
-        Painter->SetOpacity(Opacity);
+        Painter->SetOpacity(AccumulatedOpacity);
         Painter->OnPaint(Context);
     }
 


### PR DESCRIPTION
## Description

#### **Problem:**
Currently, opacity is calculated by **combining the opacity of all `UWidgets`** using `UWidget::GetParent()`. However, this approach fails in cases where **the parent widget is not a `UPanelWidget`** but still contributes to opacity (e.g., `SOverlay`, `SBox`, etc.). 

#### **Fix:** 
Instead of relying on `UWidget::GetParent()`, this fix **traverses the `SWidget` hierarchy** directly using `GetParentWidget()` from `SWidget`, ensuring opacity is correctly calculated regardless of the widget type. 

#### **Impact:** 
* **Fixes incorrect opacity calculation for non-panel parents** (e.g., `SOverlay` widgets). 
* **Ensures that all parent widgets affecting opacity are considered, even if they aren't UPanelWidgets.** 
* * * 
### **Steps to Reproduce:** 
1. Create a **User Widget** in Blueprint. 
2. Add the **FakeBloom** widget inside it, along with some other UI content.
3. Set the `RenderOpacity` of the **UserWidget** to a value **<1**. 
4. Observe that: 
   * **Expected:** Both the bloom effect and content should respect the reduced opacity. 
   * **Actual (Bug):** Content respects opacity, but FakeBloom **remains at full opacity**.